### PR TITLE
docs: add project manifest

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": 1,
+  "project": {
+    "repo": "SylphxAI/ast",
+    "name": "SylphxAI AST",
+    "lifecycle": "active",
+    "layer": "library",
+    "summary": "TypeScript monorepo for AST parsing tools, starting with JavaScript parsing through ANTLR and shared core AST interfaces.",
+    "goals": [
+      "Provide shared AST core interfaces through @sylphlab/ast-core.",
+      "Provide JavaScript parsing through @sylphlab/ast-javascript using ANTLR-generated parser code.",
+      "Maintain package documentation and a VitePress documentation site for the AST toolkit."
+    ],
+    "nonGoals": [
+      "Own downstream code transformation products or application-specific refactors.",
+      "Own parser implementations for every language until those packages are explicitly added here.",
+      "Own enterprise engineering doctrine, standards, or project manifest schema."
+    ]
+  },
+  "boundaries": {
+    "owns": [
+      {
+        "name": "ast-core-package",
+        "description": "The shared AST node interfaces and core package under packages/core."
+      },
+      {
+        "name": "javascript-parser-package",
+        "description": "The JavaScript/ECMAScript grammar, ANTLR-generated parser integration, custom AST visitor, and package contract under packages/javascript."
+      },
+      {
+        "name": "ast-documentation",
+        "description": "Repository README, generated package docs, and the VitePress documentation site under docs."
+      }
+    ],
+    "doesNotOwn": [
+      "Downstream code transformation products, application-specific refactors, or consumer runtime behavior.",
+      "Language parser packages not explicitly implemented in this repository.",
+      "Enterprise doctrine and manifest schema owned by SylphxAI/doctrine."
+    ],
+    "publicSurfaces": [
+      {
+        "type": "documentation",
+        "name": "Repository README",
+        "location": "README.md"
+      },
+      {
+        "type": "manifest",
+        "name": "Root package scripts and workspace metadata",
+        "location": "package.json"
+      },
+      {
+        "type": "package",
+        "name": "@sylphlab/ast-core",
+        "location": "packages/core/"
+      },
+      {
+        "type": "package",
+        "name": "@sylphlab/ast-javascript",
+        "location": "packages/javascript/"
+      },
+      {
+        "type": "documentation",
+        "name": "Documentation site",
+        "location": "docs/"
+      },
+      {
+        "type": "workflow",
+        "name": "Release workflow",
+        "location": ".github/workflows/release.yml"
+      }
+    ],
+    "allowedDependencies": [
+      {
+        "repo": "SylphxAI/doctrine",
+        "surface": "project manifest schema and engineering doctrine",
+        "direction": "peer-public"
+      },
+      {
+        "repo": "SylphxAI/.github",
+        "surface": "reusable release workflow",
+        "direction": "upstream-shared"
+      }
+    ],
+    "forbiddenCouplings": [
+      "Do not add product-specific code transformation behavior for a downstream application to the shared AST packages.",
+      "Do not treat the JavaScript parser package as authority for languages that are not explicitly implemented here.",
+      "Do not fork doctrine standards into this repository."
+    ]
+  },
+  "documentation": {
+    "adr": {
+      "path": "docs/adr/",
+      "status": "planned"
+    },
+    "specs": {
+      "path": "docs/guide/",
+      "status": "present"
+    },
+    "catalog": {
+      "path": ".doctrine/project.json",
+      "status": "present"
+    },
+    "runbooks": {
+      "path": "docs/DEPLOYMENT.md",
+      "status": "present"
+    },
+    "generatedReferences": {
+      "path": "docs/api/",
+      "status": "present"
+    }
+  },
+  "delivery": {
+    "ciModel": "github-actions-reusable-release-on-main",
+    "requiredContexts": [],
+    "deployPath": "Main-branch Release workflow delegates to SylphxAI/.github reusable release workflow; docs/DEPLOYMENT.md documents Vercel deployment for the documentation site.",
+    "productionProof": "bun run validate, successful package build/tests, successful release workflow for package changes, and documentation deployment/readback for docs changes.",
+    "recoveryClass": "source-revertable-with-package-forward-fix"
+  },
+  "adoption": {
+    "status": "baseline",
+    "gaps": [
+      {
+        "id": "pr-validation-workflow-missing",
+        "description": "The repository has a main-branch release workflow, but no PR validation workflow or required context is recorded for bun run validate.",
+        "owner": "SylphxAI/ast",
+        "target": "central ADR-29 required-context rollout or repo-local package validation gate"
+      },
+      {
+        "id": "parser-implementation-gap",
+        "description": "memory-bank/project_brief.md records AstBuilderVisitor implementation and grammar/position tracking as the next objective, so production lifecycle should wait for package behavior proof.",
+        "owner": "SylphxAI/ast",
+        "target": "before production lifecycle promotion"
+      },
+      {
+        "id": "tooling-doc-drift",
+        "description": "README and deployment docs reference pnpm workflows while package.json declares bun@1.3.1 and bun scripts; normalize tooling docs before enforcing package admission gates.",
+        "owner": "SylphxAI/ast",
+        "target": "next package documentation pass"
+      }
+    ]
+  }
+}

--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -4,7 +4,7 @@
     "repo": "SylphxAI/ast",
     "name": "SylphxAI AST",
     "lifecycle": "active",
-    "layer": "library",
+    "layer": "foundation",
     "summary": "TypeScript monorepo for AST parsing tools, starting with JavaScript parsing through ANTLR and shared core AST interfaces.",
     "goals": [
       "Provide shared AST core interfaces through @sylphlab/ast-core.",
@@ -110,11 +110,11 @@
     }
   },
   "delivery": {
-    "ciModel": "github-actions-reusable-release-on-main",
+    "ciModel": "legacy-ci",
     "requiredContexts": [],
     "deployPath": "Main-branch Release workflow delegates to SylphxAI/.github reusable release workflow; docs/DEPLOYMENT.md documents Vercel deployment for the documentation site.",
     "productionProof": "bun run validate, successful package build/tests, successful release workflow for package changes, and documentation deployment/readback for docs changes.",
-    "recoveryClass": "source-revertable-with-package-forward-fix"
+    "recoveryClass": "forward-fix-only"
   },
   "adoption": {
     "status": "baseline",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Instructions
+
+This repository consumes the Sylphx engineering doctrine from [SylphxAI/doctrine](https://github.com/SylphxAI/doctrine).
+
+Before changing files here:
+
+- Read [PROJECT.md](./PROJECT.md) and [`.doctrine/project.json`](./.doctrine/project.json) for this repository's goal, lifecycle, boundary, public surfaces, and adoption gaps.
+- Read `SylphxAI/doctrine` `AGENTS.md`, `PRINCIPLES.md`, and `ADR.md`, then load any triggered standards.
+- Keep AST package behavior generic and language-package scoped; downstream product transformations belong in consuming repositories unless promoted through an explicit shared package contract.
+
+Do not add product-specific transformation behavior here. This repository owns AST packages and documentation only.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -5,7 +5,7 @@ SylphxAI/ast is a TypeScript monorepo for AST parsing tools, starting with JavaS
 ## Lifecycle
 
 - State: `active`
-- Layer: `library`
+- Layer: `foundation`
 - Machine manifest: [`.doctrine/project.json`](./.doctrine/project.json)
 
 ## Goals

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -1,0 +1,38 @@
+# SylphxAI AST
+
+SylphxAI/ast is a TypeScript monorepo for AST parsing tools, starting with JavaScript parsing through ANTLR and shared core AST interfaces.
+
+## Lifecycle
+
+- State: `active`
+- Layer: `library`
+- Machine manifest: [`.doctrine/project.json`](./.doctrine/project.json)
+
+## Goals
+
+- Provide shared AST core interfaces through `@sylphlab/ast-core`.
+- Provide JavaScript parsing through `@sylphlab/ast-javascript` using ANTLR-generated parser code.
+- Maintain package documentation and a VitePress documentation site for the AST toolkit.
+
+## Non-Goals
+
+- This repository does not own downstream code transformation products or application-specific refactors.
+- This repository does not own parser implementations for every language until those packages are explicitly added here.
+- This repository does not own enterprise engineering doctrine.
+
+## Boundary
+
+This repository owns the AST package monorepo, JavaScript grammar/parser package, shared AST core package, package release workflow, and documentation site. Downstream consumers, product-specific code transformations, generated app behavior, and enterprise doctrine remain outside this repository.
+
+## Public Surfaces
+
+- Repository README: [`README.md`](./README.md)
+- Root package scripts: [`package.json`](./package.json)
+- Core package: [`packages/core/`](./packages/core/)
+- JavaScript parser package: [`packages/javascript/`](./packages/javascript/)
+- Documentation site: [`docs/`](./docs/)
+- Release workflow: [`.github/workflows/release.yml`](./.github/workflows/release.yml)
+
+## Delivery
+
+The repository has a main-branch release workflow that delegates to the central SylphxAI/.github reusable release workflow. Meaningful proof is `bun run validate`, successful package build/tests, successful release workflow for package changes, and documentation deployment/readback for docs changes. This manifest slice is documentation-only and does not change package code, release behavior, or deployment configuration.


### PR DESCRIPTION
## Summary
- add PROJECT.md with repo goal, lifecycle, boundary, public surfaces, and delivery notes
- add .doctrine/project.json for central doctrine audit
- add AGENTS.md pointer to repo-local manifest and SylphxAI/doctrine

## Validation
- python3 -m json.tool .doctrine/project.json
- python3 -m json.tool package.json packages/core/package.json packages/javascript/package.json
- Ruby YAML parse for workflows
- git diff --check
- doctrine project-control-plane-audit.py --repo SylphxAI/ast --ref codex/project-manifest-ast --fail-on-drift --json => PRESENT

## Notes
- Documentation-only; no package code, release workflow, docs deployment, or package metadata changed.
- AST is classified as foundation under current doctrine schema vocab.
- Package publication recovery is recorded as forward-fix-only.