### PR TITLE
Add ADR-81 selector facts

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -5,6 +5,7 @@
     "name": "SylphxAI AST",
     "lifecycle": "active",
     "layer": "foundation",
+    "policyPool": "library-package",
     "summary": "TypeScript monorepo for AST parsing tools, starting with JavaScript parsing through ANTLR and shared core AST interfaces.",
     "goals": [
       "Provide shared AST core interfaces through @sylphlab/ast-core.",
@@ -111,6 +112,7 @@
   },
   "delivery": {
     "ciModel": "legacy-ci",
+    "deployable": false,
     "requiredContexts": [],
     "deployPath": "Main-branch Release workflow delegates to SylphxAI/.github reusable release workflow; docs/DEPLOYMENT.md documents Vercel deployment for the documentation site.",
     "productionProof": "bun run validate, successful package build/tests, successful release workflow for package changes, and documentation deployment/readback for docs changes.",


### PR DESCRIPTION
## Summary

- Add ADR-81 selector manifest facts for SylphxAI/ast.
- Classify the repo as policyPool=library-package and deployable=false based on its foundation package monorepo boundary.

## Validation

- python3 -m json.tool .doctrine/project.json
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --local . --fail-on-drift --json -> PRESENT
- git diff --check
- python3 /Users/kyle/.doctrine/scripts/project-control-plane-audit.py --repo SylphxAI/ast --ref codex/adr81-selector-facts --fail-on-drift --json -> PRESENT
- python3 /Users/kyle/.doctrine/scripts/repo-selector-value-projection.py --repo SylphxAI/ast --ref codex/adr81-selector-facts --fail-on-blocked --json -> READY

Part of SylphxAI/doctrine#87.