### PR TITLE
Dogfood GroundAtlas 0.1.3 scorecards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,20 +44,21 @@ jobs:
 
       - name: GroundAtlas package dogfood
         id: groundatlas
-        uses: SylphxAI/groundatlas@v0.1.2
+        uses: SylphxAI/groundatlas@v0.1.3
         with:
-          package-spec: groundatlas@0.1.2
+          package-spec: groundatlas@0.1.3
           output-dir: .groundatlas-pilot
           require-atlas: "true"
           strict: "true"
 
       - name: Assert GroundAtlas truth boundary
         run: |
-          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" <<'NODE'
-          const [manifestPath, fleetPath] = process.argv.slice(2);
+          node - "${{ steps.groundatlas.outputs.manifest-report-path }}" "${{ steps.groundatlas.outputs.fleet-report-path }}" "${{ steps.groundatlas.outputs.fleet-markdown-report-path }}" <<'NODE'
+          const [manifestPath, fleetPath, fleetMarkdownPath] = process.argv.slice(2);
           const { readFileSync } = require("node:fs");
           const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
           const fleet = JSON.parse(readFileSync(fleetPath, "utf8"));
+          const fleetMarkdown = readFileSync(fleetMarkdownPath, "utf8");
           const project = fleet.projects?.[0];
 
           function assert(condition, message) {
@@ -72,6 +73,8 @@ jobs:
           assert(project?.status === "adopted", "This repository must be adopted in the GroundAtlas fleet report.");
           assert(project?.manifest?.path === "project.manifest.json", "Fleet report must select project.manifest.json.");
           assert(project?.manifestAdapters?.some((item) => item.path === ".doctrine/project.json" && item.adapter === true), "Fleet report must keep .doctrine/project.json as an adapter.");
+          assert(fleetMarkdown.includes("# GroundAtlas fleet adoption report"), "Markdown fleet scorecard must include the report title.");
+          assert(fleetMarkdown.includes("Summary: 1 adopted, 0 warning, 0 blocked, 1 total."), "Markdown fleet scorecard must include the adopted summary.");
           NODE
 
       - name: Upload GroundAtlas reports
@@ -82,3 +85,4 @@ jobs:
           path: |
             ${{ steps.groundatlas.outputs.manifest-report-path }}
             ${{ steps.groundatlas.outputs.fleet-report-path }}
+            ${{ steps.groundatlas.outputs.fleet-markdown-report-path }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,13 @@ Do not add product-specific transformation behavior here. This repository owns A
 bun install --frozen-lockfile
 bun run validate
 node --test test/project-control.node-test.mjs
-npm exec --yes --package groundatlas@0.1.2 -- ga update --out .groundatlas-pilot
-npm exec --yes --package groundatlas@0.1.2 -- ga audit --out .groundatlas-pilot
-npm exec --yes --package groundatlas@0.1.2 -- ga manifest --out .groundatlas-pilot --json
-npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json
+npm exec --yes --package groundatlas@0.1.3 -- ga update --out .groundatlas-pilot
+npm exec --yes --package groundatlas@0.1.3 -- ga audit --out .groundatlas-pilot
+npm exec --yes --package groundatlas@0.1.3 -- ga manifest --out .groundatlas-pilot --json
+npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json
+npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict
 ```
 
 ## GroundAtlas Boundary
 
-`project.manifest.json` is the vendor-neutral GroundAtlas control file; `.doctrine/project.json` is the Sylphx-specific adapter and generated `.groundatlas*` reports are not SSOT. Release behavior runs through `.github/workflows/release.yml`, whose caller must grant `id-token: write` for trusted publish identity.
+`project.manifest.json` is the vendor-neutral GroundAtlas control file; `.doctrine/project.json` is the Sylphx-specific adapter and generated `.groundatlas*` files plus GroundAtlas JSON/Markdown reports are not SSOT. Release behavior runs through `.github/workflows/release.yml`, whose caller must grant `id-token: write` for trusted publish identity.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -42,4 +42,4 @@ Pull requests and merge groups run `bun run validate`, project-control boundary 
 
 ## Project Control
 
-`project.manifest.json` is the vendor-neutral control file for GroundAtlas and external agents. `.doctrine/project.json` remains the Sylphx Doctrine adapter and local governance catalog. Generated `.groundatlas*` reports are evidence and navigation only; they are not source of truth.
+`project.manifest.json` is the vendor-neutral control file for GroundAtlas and external agents. `.doctrine/project.json` remains the Sylphx Doctrine adapter and local governance catalog. Generated `.groundatlas*` files plus GroundAtlas JSON/Markdown reports are evidence and navigation only; they are not source of truth.

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ docs(readme): update installation instructions
 This repository dogfoods [GroundAtlas](https://github.com/SylphxAI/groundatlas)
 through CI. The vendor-neutral project facts live in `project.manifest.json`;
 Sylphx-specific governance facts stay in `.doctrine/project.json`; generated
-`.groundatlas*` reports are evidence/navigation only, not source of truth.
+`.groundatlas*` files plus GroundAtlas JSON/Markdown reports are evidence/navigation only, not source of truth.
 
 Package releases run through the shared Sylphx release workflow and are complete
 only after CI, the Release workflow, and npm registry readback for changed AST

--- a/docs/adr/0001-groundatlas-project-control-gate.md
+++ b/docs/adr/0001-groundatlas-project-control-gate.md
@@ -14,7 +14,7 @@ permission required by the shared Sylphx release workflow for trusted npm
 publishing.
 
 The project-control surface must not make `.doctrine/project.json` a public
-default and must not make generated `.groundatlas*` reports authoritative. This
+default and must not make generated `.groundatlas*` files or GroundAtlas JSON/Markdown reports authoritative. This
 change must not alter AST package behavior, generated parser code, documentation
 deployment, or downstream code-transformation responsibilities.
 
@@ -25,7 +25,7 @@ Add:
 - a vendor-neutral `project.manifest.json`;
 - a CI workflow that runs `bun run validate`, including generated parser
   freshness, workspace typecheck, package tests, and package build;
-- a CI step using `SylphxAI/groundatlas@v0.1.2` with `groundatlas@0.1.2`;
+- a CI step using `SylphxAI/groundatlas@v0.1.3` with `groundatlas@0.1.3`;
 - assertions that GroundAtlas selects `project.manifest.json`, reports
   `.doctrine/project.json` only as an adapter, and has zero strict fleet
   warnings/blockers;
@@ -44,4 +44,4 @@ Add:
   governance catalog.
 - Release proof remains a successful main Release workflow plus npm registry
   readback for changed packages.
-- Generated `.groundatlas*` reports remain evidence/navigation only.
+- Generated `.groundatlas*` files plus GroundAtlas JSON/Markdown reports remain evidence/navigation only.

--- a/docs/specs/project-control-gate.md
+++ b/docs/specs/project-control-gate.md
@@ -12,7 +12,7 @@ The gate validates repository control-plane facts only:
 
 - neutral identity and truth homes live in `project.manifest.json`;
 - Sylphx-specific governance facts remain in `.doctrine/project.json`;
-- generated `.groundatlas*` outputs are evidence/navigation only;
+- generated `.groundatlas*` files plus GroundAtlas JSON/Markdown reports are evidence/navigation only;
 - package validation remains `bun run validate`, including generated parser
   freshness, package typecheck, tests, and build;
 - package release proof remains the Release workflow plus registry/readback when
@@ -31,11 +31,12 @@ organization rulesets.
 3. install dependencies with `bun install --frozen-lockfile`;
 4. run `bun run validate`;
 5. run `node --test test/project-control.node-test.mjs`;
-6. run `SylphxAI/groundatlas@v0.1.2` with `package-spec:
-   groundatlas@0.1.2`, `require-atlas: "true"`, and `strict: "true"`;
+6. run `SylphxAI/groundatlas@v0.1.3` with `package-spec:
+   groundatlas@0.1.3`, `require-atlas: "true"`, and `strict: "true"`;
 7. assert that GroundAtlas selects `project.manifest.json` and treats
    `.doctrine/project.json` only as an adapter;
-8. upload the manifest and fleet reports as `groundatlas-package-dogfood`.
+8. assert the Markdown fleet scorecard title and adopted summary;
+9. upload the manifest, JSON fleet, and Markdown fleet reports as `groundatlas-package-dogfood`.
 
 ## Acceptance
 

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -102,12 +102,12 @@
     },
     {
       "name": "groundatlas:fleet",
-      "command": "npm exec --yes --package groundatlas@0.1.2 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json",
-      "purpose": "Prove the vendor-neutral manifest is selected and generated GroundAtlas files are navigation-only."
+      "command": "npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json",
+      "purpose": "Prove the vendor-neutral manifest is selected and generated GroundAtlas JSON/Markdown reports are evidence-only."
     }
   ],
   "adoption": {
     "status": "adopted",
-    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog. Generated .groundatlas* reports are evidence/navigation only, not source of truth."
+    "notes": "Vendor-neutral GroundAtlas manifest for package/action dogfooding. .doctrine/project.json remains the Sylphx Doctrine adapter and local governance catalog. Generated .groundatlas* files plus GroundAtlas JSON/Markdown reports are evidence/navigation only, not source of truth."
   }
 }

--- a/test/project-control.node-test.mjs
+++ b/test/project-control.node-test.mjs
@@ -43,10 +43,12 @@ test("CI runs package validation and dogfoods the released GroundAtlas package/a
   assert.ok(workflow.includes("bun install --frozen-lockfile"));
   assert.ok(workflow.includes("actions/setup-java@"));
   assert.ok(workflow.includes("bun run validate"));
-  assert.ok(workflow.includes("uses: SylphxAI/groundatlas@v0.1.2"));
-  assert.ok(workflow.includes("package-spec: groundatlas@0.1.2"));
+  assert.ok(workflow.includes("uses: SylphxAI/groundatlas@v0.1.3"));
+  assert.ok(workflow.includes("package-spec: groundatlas@0.1.3"));
   assert.ok(workflow.includes('require-atlas: "true"'));
   assert.ok(workflow.includes('strict: "true"'));
+  assert.ok(workflow.includes("fleet-markdown-report-path"));
+  assert.ok(workflow.includes("Summary: 1 adopted, 0 warning, 0 blocked, 1 total."));
   assert.ok(workflow.includes("project.manifest.json"));
   assert.ok(workflow.includes(".doctrine/project.json"));
 });


### PR DESCRIPTION
## Summary
- bump AST's GroundAtlas action/package gate to the published `groundatlas@0.1.3` / `SylphxAI/groundatlas@v0.1.3`
- assert and upload the Markdown fleet scorecard artifact alongside JSON reports
- keep the SSOT boundary explicit: `project.manifest.json` is vendor-neutral truth, `.doctrine/project.json` is the Sylphx adapter, generated reports are evidence/read-models only

## Validation
- `bun install --frozen-lockfile`
- `bun run validate`
- `node --test test/project-control.node-test.mjs`
- `npm exec --yes --package groundatlas@0.1.3 -- ga update --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.3 -- ga manifest --out .groundatlas-pilot --json > /tmp/ast-groundatlas-0.1.3/manifest.json`
- `npm exec --yes --package groundatlas@0.1.3 -- ga audit --out .groundatlas-pilot`
- `npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict --json > /tmp/ast-groundatlas-0.1.3/fleet.json`
- `npm exec --yes --package groundatlas@0.1.3 -- ga fleet . --out .groundatlas-pilot --require-atlas --strict > /tmp/ast-groundatlas-0.1.3/fleet.md`

## Local GroundAtlas readback
- manifest selected: `project.manifest.json` (`adapter=false`)
- Doctrine adapter preserved: `.doctrine/project.json` (`adapter=true`)
- fleet summary: `1 adopted, 0 warning, 0 blocked, 1 total`
- Markdown scorecard contains `# GroundAtlas fleet adoption report` and the adopted summary
