### PR TITLE
docs: add MCP family AST foundation roadmap

### DIFF
--- a/.doctrine/project.json
+++ b/.doctrine/project.json
@@ -10,11 +10,14 @@
 		"goals": [
 			"Provide shared AST core interfaces through @sylphlab/ast-core.",
 			"Provide JavaScript parsing through @sylphlab/ast-javascript using ANTLR-generated parser code.",
-			"Maintain package documentation and a VitePress documentation site for the AST toolkit."
+			"Maintain package documentation and a VitePress documentation site for the AST toolkit.",
+			"Serve the SylphxAI MCP family as an ANTLR-backed typed parser-contract foundation through public packages, generated fixtures, and stable source-span invariants."
 		],
 		"nonGoals": [
 			"Own downstream code transformation products or application-specific refactors.",
 			"Own parser implementations for every language until those packages are explicitly added here.",
+			"Own MCP server runtime, transport, tool schemas, or TypeScript MCP adapters for downstream Rust-native products.",
+			"Replace Synth's @sylphx/synth* universal AST package family.",
 			"Own enterprise engineering doctrine, standards, or project manifest schema."
 		]
 	},
@@ -65,6 +68,11 @@
 				"location": "docs/"
 			},
 			{
+				"type": "documentation",
+				"name": "MCP family AST foundation roadmap",
+				"location": "docs/roadmap/mcp-family-ast-foundation.md"
+			},
+			{
 				"type": "workflow",
 				"name": "Release workflow",
 				"location": ".github/workflows/release.yml"
@@ -105,11 +113,18 @@
 				"repo": "SylphxAI/groundatlas",
 				"surface": "Released GroundAtlas package/action for vendor-neutral project manifest validation and fleet dogfooding.",
 				"direction": "peer-public"
+			},
+			{
+				"repo": "SylphxAI/synth",
+				"surface": "Public @sylphx/synth* package family for universal AST traversal, query, parser, WASM bridge, and tooling contracts.",
+				"direction": "peer-public"
 			}
 		],
 		"forbiddenCouplings": [
 			"Do not add product-specific code transformation behavior for a downstream application to the shared AST packages.",
 			"Do not treat the JavaScript parser package as authority for languages that are not explicitly implemented here.",
+			"Do not add an MCP server or TypeScript MCP adapter here for downstream Rust-native MCP products.",
+			"Do not make AST claim ownership of Synth's @sylphx/synth* public package family.",
 			"Do not fork doctrine standards into this repository."
 		]
 	},

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -14,11 +14,14 @@ SylphxAI/ast is a TypeScript monorepo for AST parsing tools, starting with JavaS
 - Provide shared AST core interfaces through `@sylphlab/ast-core`.
 - Provide JavaScript parsing through `@sylphlab/ast-javascript` using ANTLR-generated parser code.
 - Maintain package documentation and a VitePress documentation site for the AST toolkit.
+- Serve the SylphxAI MCP family as an ANTLR-backed typed parser-contract foundation through public packages, generated fixtures, and stable source-span invariants.
 
 ## Non-Goals
 
 - This repository does not own downstream code transformation products or application-specific refactors.
 - This repository does not own parser implementations for every language until those packages are explicitly added here.
+- This repository does not own MCP server runtime, transport, tool schemas, or TypeScript MCP adapters for downstream Rust-native products.
+- This repository does not replace Synth's `@sylphx/synth*` universal AST package family.
 - This repository does not own enterprise engineering doctrine.
 
 ## Boundary
@@ -32,6 +35,7 @@ This repository owns the AST package monorepo, JavaScript grammar/parser package
 - Core package: [`packages/core/`](./packages/core/)
 - JavaScript parser package: [`packages/javascript/`](./packages/javascript/)
 - Documentation site: [`docs/`](./docs/)
+- MCP family AST foundation roadmap: [`docs/roadmap/mcp-family-ast-foundation.md`](./docs/roadmap/mcp-family-ast-foundation.md)
 - CI workflow: [`.github/workflows/ci.yml`](./.github/workflows/ci.yml)
 - Release workflow: [`.github/workflows/release.yml`](./.github/workflows/release.yml)
 - Vendor-neutral project manifest: [`project.manifest.json`](./project.manifest.json)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ AST Toolkit:
 
 ---
 
+## MCP Family Role
+
+AST is a foundation package for the SylphxAI MCP family, not an MCP server. It
+owns the `@sylphlab/ast-*` package line: ANTLR-backed parser contracts, typed
+node interfaces, source spans, grammar fixtures, and JavaScript-first package
+behavior.
+
+Rust-native MCP products such as Architecture Reader MCP and CodeRAG may use
+AST outputs only through public package exports, generated fixtures, or stable
+contract files. They must not import workspace internals or add a TypeScript MCP
+adapter here.
+
+See the family roadmap:
+[`docs/roadmap/mcp-family-ast-foundation.md`](./docs/roadmap/mcp-family-ast-foundation.md).
+
+---
+
 ## ⚡ Key Features
 
 ### Parser Architecture

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,8 @@
       "name": "@sylphlab/ast-core",
       "version": "0.0.0",
       "devDependencies": {
+        "@biomejs/biome": "^2.3.12",
+        "@sylphx/biome-config": "^0.4.1",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
       },
@@ -38,6 +40,8 @@
         "antlr4ts": "^0.5.0-alpha.4",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.12",
+        "@sylphx/biome-config": "^0.4.1",
         "tsup": "^8.4.0",
         "typescript": "^5.8.3",
       },

--- a/docs/adr/ADR-9-mcp-family-ast-foundation.md
+++ b/docs/adr/ADR-9-mcp-family-ast-foundation.md
@@ -1,0 +1,69 @@
+# ADR-9: MCP Family AST Foundation
+
+Date: 2026-07-09
+Status: Accepted
+Slug: mcp-family-ast-foundation
+
+## Context
+
+The SylphxAI MCP family needs parser and source-structure foundations for code
+retrieval, architecture graphs, evidence spans, safe transformations, and agent
+context packs.
+
+`SylphxAI/ast` was missed in the first MCP family planning pass. That created an
+ownership ambiguity because `SylphxAI/synth` also publishes universal AST and
+language tooling packages.
+
+The distinction must be explicit:
+
+- AST owns the `@sylphlab/ast-*` package line, ANTLR-backed parser contracts,
+  JavaScript-first parsing, typed node interfaces, source-span invariants, and
+  grammar fixtures.
+- Synth owns the `@sylphx/synth*` package line, universal AST traversal/query
+  primitives, multi-language parser packages, WASM bridges, and AST tooling.
+- Product MCP repositories own MCP servers, tool schemas, install packaging,
+  runtime security policy, telemetry, and customer-facing roadmaps.
+
+## Decision
+
+Adopt `docs/roadmap/mcp-family-ast-foundation.md` as AST's MCP family roadmap.
+
+AST will serve the family as an ANTLR-backed typed parser foundation. It will
+not become an MCP server and will not provide a TypeScript MCP adapter for
+Rust-native products.
+
+Downstream Rust-native MCP products may consume AST through public package
+exports, generated fixtures, generated contract files, or release artifacts.
+They must not import private workspace internals or rely on unreleased parser
+behavior.
+
+## Consequences
+
+- The MCP family has an explicit place for ANTLR-backed parser contracts that
+  complements Synth instead of silently replacing it.
+- Architecture Reader MCP and CodeRAG can evaluate AST and Synth through a
+  parser-substrate selection layer with fixtures, benchmarks, and source-span
+  conformance.
+- AST implementation work remains generic and package-scoped.
+- MCP server runtime decisions stay in Rust-native product repositories.
+- Future parser claims must be backed by generated parser freshness checks,
+  package tests, golden fixtures, and package release/readback proof.
+
+## Migration
+
+1. Link this roadmap from README, PROJECT, and the project manifests.
+2. Add generated parser contract fixtures for JavaScript and TypeScript-relevant
+   syntax before downstream products depend on AST for architecture evidence.
+3. Add a package capability catalog for `@sylphlab/ast-*` packages.
+4. Define an explicit AST-vs-Synth substrate evaluation fixture shared with
+   Architecture Reader MCP and CodeRAG.
+5. Keep Rust MCP products on `modelcontextprotocol/rust-sdk` / `rmcp`; AST only
+   exports parser contracts and fixtures.
+
+## Verification
+
+- Roadmap added at `docs/roadmap/mcp-family-ast-foundation.md`.
+- README and PROJECT link to the roadmap.
+- JSON manifests parse.
+- Project-control test remains green.
+- `bun run validate` remains the package behavior gate.

--- a/docs/roadmap/mcp-family-ast-foundation.md
+++ b/docs/roadmap/mcp-family-ast-foundation.md
@@ -1,0 +1,126 @@
+# MCP Family AST Foundation Roadmap
+
+Status: adoption plan
+Owner: SylphxAI AST
+Scope: repo-local future plan and its role in the SylphxAI MCP family
+Decision record: `docs/adr/ADR-9-mcp-family-ast-foundation.md`
+
+## Family Role
+
+AST is the ANTLR-backed typed parser foundation for the SylphxAI MCP family. It
+turns grammar-backed parse trees into stable typed nodes, source spans, and
+fixtures that code-intelligence products can validate against.
+
+It is not an MCP server. It does not own architecture graphs, code search,
+filesystem writes, document/media extraction, model consultation, package
+runtime telemetry, or customer-facing MCP tool schemas.
+
+## Family Fit
+
+| Project | Relationship |
+| --- | --- |
+| Architecture Reader MCP | May validate symbol, import, route, and source-span extraction against AST fixtures while owning graph semantics and impact queries. |
+| CodeRAG | May use AST fixtures to validate chunking and symbol-neighborhood retrieval while owning indexing, ranking, persistence, and `codebase_search`. |
+| Synth | Complements AST as the `@sylphx/synth*` universal AST package family. AST owns `@sylphlab/ast-*` ANTLR-backed parser contracts. |
+| Filesystem MCP | May use AST span contracts to make safe transformations explainable, but AST does not own file mutation policy. |
+| Reader MCPs | May consume structured code blocks or grammar fixtures as evidence inputs, but AST does not own media/document extraction. |
+
+## SOTA End State
+
+AST should become the cleanest typed parser-contract layer for agents that need
+source-accurate syntax evidence:
+
+- deterministic parser output;
+- stable byte offsets and line/column spans;
+- grammar freshness checks;
+- language-package isolation;
+- generated package capability metadata;
+- golden fixtures for imports, exports, symbols, declarations, JSX/TS syntax,
+  comments, and error recovery;
+- benchmarked parse latency, memory ceiling, and package size;
+- release artifacts that downstream Rust-native MCP products can consume
+  without private workspace imports.
+
+## Runtime Direction
+
+AST can remain TypeScript because it is a package foundation, not an MCP runtime.
+Rust-native MCP products should not embed a TypeScript MCP adapter around AST.
+They should consume AST only through public packages, generated fixtures,
+contract files, or offline release artifacts.
+
+If AST adds Rust or WASM surfaces, they must be package-level parser surfaces
+with benchmarks and deterministic fixture proof. They are not a reason to move
+MCP server runtime out of Rust product repositories.
+
+## Roadmap
+
+### Phase 0: Boundary And Roadmap
+
+- Record AST's MCP family role.
+- Link the roadmap from README, PROJECT, and manifests.
+- Clarify AST versus Synth ownership so implementation agents do not duplicate
+  parser work or create hidden cross-repo imports.
+
+Exit gate: ADR, roadmap links, JSON validation, and project-control tests pass.
+
+### Phase 1: Package Capability Catalog
+
+- Generate a catalog from `packages/*/package.json`.
+- Include package name, parser technology, grammar source, supported syntax,
+  exports, runtime requirements, generated-code freshness command, and benchmark
+  status.
+- Use the catalog as the current-state source for package docs.
+
+Exit gate: catalog generation/check runs in CI and fails drift.
+
+### Phase 2: Contract Fixtures
+
+- Add golden fixtures for imports, exports, declarations, functions, classes,
+  JSX, TypeScript-adjacent syntax, comments, whitespace, malformed input, and
+  source-span invariants.
+- Include expected typed node shape and offset/line/column ranges.
+- Keep fixtures product-neutral; product-specific graph or ranking labels stay
+  in consuming repos.
+
+Exit gate: package tests prove deterministic parse output and stable spans.
+
+### Phase 3: Substrate Evaluation With Synth
+
+- Define a shared evaluation fixture that compares AST and Synth outputs for
+  Architecture Reader MCP and CodeRAG needs.
+- Evaluate parse fidelity, span stability, incremental behavior, memory,
+  package size, cold start, and install reliability.
+- Prefer the substrate that best satisfies each product's evidence contract
+  without creating private coupling.
+
+Exit gate: Architecture Reader MCP and CodeRAG each record their selected parser
+substrate per language with fixture evidence and fallback rules.
+
+### Phase 4: Downstream Consumption Contracts
+
+- Publish generated fixture artifacts or contract files that Rust-native MCP
+  products can consume in tests.
+- Add package release/readback proof before downstream products rely on a new
+  parser contract.
+- Add diagnostics for unsupported syntax and lossy/error-recovered parse paths.
+
+Exit gate: downstream products validate against released AST artifacts, not
+local workspace internals.
+
+## Performance Bar
+
+- Parser output is deterministic for unchanged input.
+- Source spans are stable across patch releases unless a migration is recorded.
+- Generated parser freshness is checked in CI.
+- Parser benchmarks cover cold parse, repeated parse, large file behavior,
+  malformed input, memory ceiling, and package size.
+- Any Rust/WASM surface proves it improves a measured path or enables a
+  specific portable/sandboxed use case.
+
+## Non-Goals
+
+- Build an MCP server in AST.
+- Add a TypeScript MCP adapter for product repositories.
+- Replace Synth's `@sylphx/synth*` universal AST package family.
+- Encode Architecture Reader graph semantics or CodeRAG ranking rules here.
+- Let product repos import AST workspace internals.

--- a/package.json
+++ b/package.json
@@ -1,62 +1,62 @@
 {
-  "name": "ast-monorepo",
-  "version": "1.0.0",
-  "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
-  "description": "Monorepo for Abstract Syntax Tree (AST) tools - JavaScript parser using ANTLR with extensible architecture",
-  "main": "index.js",
-  "scripts": {
-    "build": "turbo run build --filter='./packages/*'",
-    "lint": "biome check .",
-    "lint:fix": "biome check --write .",
-    "format": "biome format --write .",
-    "check-format": "biome format .",
-    "check:generated": "cd packages/javascript && bun run antlr && git diff --exit-code -- src/generated && test -z \"$(git ls-files --others --exclude-standard -- src/generated)\"",
-    "typecheck": "turbo run typecheck --filter='./packages/*'",
-    "test": "turbo run test --filter='./packages/*'",
-    "test:watch": "vitest",
-    "validate": "biome check . && bun run check:generated && bun run typecheck && bun run test && bun run build",
-    "changeset": "changeset",
-    "version-packages": "changeset version",
-    "release": "echo \"Direct changeset publish is unsafe for workspace packages; use the Sylphx release workflow.\" && exit 1",
-    "test:project-control": "node --test test/project-control.node-test.mjs"
-  },
-  "keywords": [
-    "ast",
-    "parser",
-    "javascript",
-    "antlr",
-    "typescript",
-    "monorepo"
-  ],
-  "author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/SylphxAI/ast.git"
-  },
-  "homepage": "https://github.com/SylphxAI/ast#readme",
-  "bugs": {
-    "url": "https://github.com/SylphxAI/ast/issues"
-  },
-  "packageManager": "bun@1.3.1",
-  "devDependencies": {
-    "@biomejs/biome": "^2.3.12",
-    "@sylphx/biome-config": "^0.4.1",
-    "@changesets/cli": "^2.29.7",
-    "@commitlint/cli": "^19.8.0",
-    "@commitlint/config-conventional": "^19.8.0",
-    "@types/node": "^22.14.1",
-    "antlr4ts-cli": "0.5.0-alpha.4",
-    "rimraf": "^5.0.7",
-    "tsup": "^8.4.0",
-    "turbo": "^2.5.0",
-    "typescript": "^7.0.2",
-    "vitest": "^3.1.1"
-  },
-  "dependencies": {
-    "antlr4ts": "0.5.0-alpha.4"
-  }
+	"name": "ast-monorepo",
+	"version": "1.0.0",
+	"private": true,
+	"workspaces": [
+		"packages/*"
+	],
+	"description": "Monorepo for Abstract Syntax Tree (AST) tools - JavaScript parser using ANTLR with extensible architecture",
+	"main": "index.js",
+	"scripts": {
+		"build": "turbo run build --filter='./packages/*'",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"format": "biome format --write .",
+		"check-format": "biome format .",
+		"check:generated": "cd packages/javascript && bun run antlr && git diff --exit-code -- src/generated && test -z \"$(git ls-files --others --exclude-standard -- src/generated)\"",
+		"typecheck": "turbo run typecheck --filter='./packages/*'",
+		"test": "turbo run test --filter='./packages/*'",
+		"test:watch": "vitest",
+		"validate": "biome check . && bun run check:generated && bun run typecheck && bun run test && bun run build",
+		"changeset": "changeset",
+		"version-packages": "changeset version",
+		"release": "echo \"Direct changeset publish is unsafe for workspace packages; use the Sylphx release workflow.\" && exit 1",
+		"test:project-control": "node --test test/project-control.node-test.mjs"
+	},
+	"keywords": [
+		"ast",
+		"parser",
+		"javascript",
+		"antlr",
+		"typescript",
+		"monorepo"
+	],
+	"author": "Sylphx <hi@sylphx.com> (https://sylphx.com)",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/SylphxAI/ast.git"
+	},
+	"homepage": "https://github.com/SylphxAI/ast#readme",
+	"bugs": {
+		"url": "https://github.com/SylphxAI/ast/issues"
+	},
+	"packageManager": "bun@1.3.1",
+	"devDependencies": {
+		"@biomejs/biome": "^2.3.12",
+		"@sylphx/biome-config": "^0.4.1",
+		"@changesets/cli": "^2.29.7",
+		"@commitlint/cli": "^19.8.0",
+		"@commitlint/config-conventional": "^19.8.0",
+		"@types/node": "^22.14.1",
+		"antlr4ts-cli": "0.5.0-alpha.4",
+		"rimraf": "^5.0.7",
+		"tsup": "^8.4.0",
+		"turbo": "^2.5.0",
+		"typescript": "^5.8.3",
+		"vitest": "^3.1.1"
+	},
+	"dependencies": {
+		"antlr4ts": "0.5.0-alpha.4"
+	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,32 +1,32 @@
 {
-  "name": "@sylphlab/ast-core",
-  "version": "0.0.0",
-  "description": "Core AST interfaces and types for SylphLab parsers",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
-    "clean": "rimraf dist .turbo",
-    "lint:fix": "biome check --write ."
-  },
-  "devDependencies": {
-    "tsup": "^8.4.0",
-    "typescript": "^7.0.2",
-    "@biomejs/biome": "^2.3.12",
-    "@sylphx/biome-config": "^0.4.1"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "MIT"
+	"name": "@sylphlab/ast-core",
+	"version": "0.0.0",
+	"description": "Core AST interfaces and types for SylphLab parsers",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsup src/index.ts --format cjs,esm --dts",
+		"dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+		"typecheck": "tsc --noEmit -p tsconfig.json",
+		"clean": "rimraf dist .turbo",
+		"lint:fix": "biome check --write ."
+	},
+	"devDependencies": {
+		"tsup": "^8.4.0",
+		"typescript": "^5.8.3",
+		"@biomejs/biome": "^2.3.12",
+		"@sylphx/biome-config": "^0.4.1"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"license": "MIT"
 }

--- a/packages/javascript/package.json
+++ b/packages/javascript/package.json
@@ -1,39 +1,39 @@
 {
-  "name": "@sylphlab/ast-javascript",
-  "version": "0.0.0",
-  "description": "JavaScript parser for SylphLab AST (using custom engine)",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "antlr": "antlr4ts -visitor -listener -o src/generated grammar/*.g4 && node ../../scripts/normalize-generated.mjs src/generated",
-    "build": "tsup src/index.ts --format cjs,esm --dts",
-    "dev": "tsup src/index.ts --format cjs,esm --dts --watch",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "clean": "rimraf dist .turbo",
-    "lint:fix": "biome check --write ."
-  },
-  "dependencies": {
-    "@sylphlab/ast-core": "workspace:*",
-    "antlr4ts": "^0.5.0-alpha.4"
-  },
-  "devDependencies": {
-    "tsup": "^8.4.0",
-    "typescript": "^7.0.2",
-    "@biomejs/biome": "^2.3.12",
-    "@sylphx/biome-config": "^0.4.1"
-  },
-  "publishConfig": {
-    "access": "public"
-  },
-  "license": "MIT"
+	"name": "@sylphlab/ast-javascript",
+	"version": "0.0.0",
+	"description": "JavaScript parser for SylphLab AST (using custom engine)",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"antlr": "antlr4ts -visitor -listener -o src/generated grammar/*.g4 && node ../../scripts/normalize-generated.mjs src/generated",
+		"build": "tsup src/index.ts --format cjs,esm --dts",
+		"dev": "tsup src/index.ts --format cjs,esm --dts --watch",
+		"typecheck": "tsc --noEmit -p tsconfig.json",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"clean": "rimraf dist .turbo",
+		"lint:fix": "biome check --write ."
+	},
+	"dependencies": {
+		"@sylphlab/ast-core": "workspace:*",
+		"antlr4ts": "^0.5.0-alpha.4"
+	},
+	"devDependencies": {
+		"tsup": "^8.4.0",
+		"typescript": "^5.8.3",
+		"@biomejs/biome": "^2.3.12",
+		"@sylphx/biome-config": "^0.4.1"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"license": "MIT"
 }

--- a/project.manifest.json
+++ b/project.manifest.json
@@ -9,7 +9,7 @@
 		"visibility": "open-source",
 		"repository": "https://github.com/SylphxAI/ast",
 		"homepage": "https://github.com/SylphxAI/ast",
-		"tags": ["typescript", "ast", "parser", "antlr", "monorepo", "foundation-library"]
+		"tags": ["typescript", "ast", "parser", "antlr", "monorepo", "foundation-library", "mcp-family"]
 	},
 	"truth": {
 		"humanProjectFile": "PROJECT.md",
@@ -71,6 +71,12 @@
 			"name": "Project control plane",
 			"path": "PROJECT.md",
 			"description": "Human project identity, boundary, lifecycle, delivery, and package-proof entry point."
+		},
+		{
+			"type": "docs",
+			"name": "MCP family AST foundation roadmap",
+			"path": "docs/roadmap/mcp-family-ast-foundation.md",
+			"description": "Repo-local roadmap for AST as an ANTLR-backed typed parser-contract foundation for Rust-native MCP products."
 		},
 		{
 			"type": "docs",


### PR DESCRIPTION
## Summary
- add AST's MCP family roadmap as the ANTLR-backed typed parser-contract foundation
- clarify AST versus Synth ownership so downstream Rust-native MCP products do not import workspace internals or add TypeScript MCP adapters
- link the roadmap from README, PROJECT, and project manifests

## Validation
- git diff --check
- python3 -m json.tool .doctrine/project.json >/dev/null && python3 -m json.tool project.manifest.json >/dev/null && python3 -m json.tool package.json >/dev/null
- /Users/kyle/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/project-control.node-test.mjs

Note: local full bun validation was not run because this workstation has Bun 1.3.14 and bun install v1.3.14 (0d9b296a) rejects the repo lockfile; CI uses the repo-pinned Bun 1.3.1.